### PR TITLE
'Updated AL-Go System Files'

### DIFF
--- a/.github/RELEASENOTES.copy.md
+++ b/.github/RELEASENOTES.copy.md
@@ -10,11 +10,20 @@ Note that when using the preview version of AL-Go for GitHub, you need to Update
 - Issue #152 Error when loading dependencies from releases
 - Issue #168 Regression in preview fixed
 
+### AppSource Apps
+- New workflow: Publish to AppSource
+- Added new GitHub Action "Deliver" to deliver build output to Storage or AppSource
+- Refactor CI/CD and Release workflows to use new deliver action
+
 ### Settings
 - New Repo setting: CICDPushBranches can be specified as an array of branches, which triggers a CI/CD workflow on commit. Default is main', release/\*, feature/\*
 - New Repo setting: CICDPullRequestBranches can be specified as an array of branches, which triggers a CI/CD workflow on pull request. Default is main
 - New Repo setting: CICDSchedule can specify a CRONTab on when you want to run CI/CD on a schedule. Note that this will disable Push and Pull Request triggers unless specified specifically using CICDPushBranches or CICDPullRequestBranches
 - New Repo setting: UpdateGitHubGoSystemFilesSchedule can specify a CRONTab on when you want to Update AL-Go System Files. Note that when running on a schedule, update AL-Go system files will perfom a direct commit and not create a pull request.
+- New project Setting: AppSourceContext should be a compressed json structure containing authContext for submitting to AppSource. The BcContainerHelperFunction New-ALGoAppSourceContext will help you create this structure.
+- New project Setting: AppSourceContinuousDelivery. Set this to true in enable continuous delivery for this project to AppSource. This requires AppSourceContext and AppSourceProductId to be set as well
+- New project Setting: AppSourceProductId should be set to the product Id of this project in AppSource
+- New project Setting: AppSourceMainAppFolder. If you have multiple appFolders, this is the folder name of the main app to submit to AppSource.
 
 ### All workflows
 - Support 2 folder levels projects (apps\w1, apps\dk etc.)
@@ -30,6 +39,7 @@ Note that when using the preview version of AL-Go for GitHub, you need to Update
 - appDependencyProbingPaths did not support multiple projects in the same repository for latestBuild dependencies
 - appDependencyProbingPaths with release=latestBuild only considered the last 30 artifacts
 - Use mutex around ReadSecrets to ensure that multiple agents on the same host doesn't clash
+- Add lfs when checking out files for CI/CD to support checking in dependencies
 
 ### CI/CD and Publish To New Environment
 - Base functionality for selecting a specific GitHub runner for an environment

--- a/.github/workflows/AddExistingAppOrTestApp.yaml
+++ b/.github/workflows/AddExistingAppOrTestApp.yaml
@@ -25,7 +25,7 @@ defaults:
 
 jobs:
   Initialization:
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
@@ -39,7 +39,7 @@ jobs:
           eventId: "DO0090"
 
   Update:
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     needs: [ Initialization ]
     steps:
       - name: Add existing app
@@ -52,7 +52,7 @@ jobs:
 
   PostProcess:
     if: always()
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     needs: [ Initialization, Update ]
     steps:
       - name: Checkout

--- a/.github/workflows/CICD.yaml
+++ b/.github/workflows/CICD.yaml
@@ -22,7 +22,7 @@ defaults:
 
 jobs:
   Initialization:
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
       settings: ${{ steps.ReadSettings.outputs.SettingsJson }}
@@ -80,7 +80,7 @@ jobs:
           Add-Content -Path $env:GITHUB_ENV -Value "DeliveryTargets=$deliveryTargetsJson"
 
   CheckForUpdates:
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     needs: [ Initialization ]
     steps:
       - name: Checkout
@@ -307,7 +307,7 @@ jobs:
       matrix:
         deliveryTarget: ${{ fromJson(needs.Initialization.outputs.deliveryTargets) }}
       fail-fast: false
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     name: Deliver to ${{ matrix.deliveryTarget }}
     steps:
       - name: Checkout
@@ -349,7 +349,7 @@ jobs:
 
   PostProcess:
     if: always()
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     needs: [ Initialization, Build, Deploy, Deliver ]
     steps:
       - name: Checkout

--- a/.github/workflows/CreateApp.yaml
+++ b/.github/workflows/CreateApp.yaml
@@ -35,7 +35,7 @@ defaults:
 
 jobs:
   Initialization:
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
@@ -49,7 +49,7 @@ jobs:
           eventId: "DO0092"
 
   CreateApp:
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     needs: [ Initialization ]
     steps:
       - name: Checkout
@@ -75,7 +75,7 @@ jobs:
 
   PostProcess:
     if: always()
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     needs: [ Initialization, CreateApp ]
     steps:
       - name: Checkout

--- a/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
+++ b/.github/workflows/CreateOnlineDevelopmentEnvironment.yaml
@@ -25,7 +25,7 @@ defaults:
 
 jobs:
   Initialization:
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
@@ -39,7 +39,7 @@ jobs:
           eventId: "DO0093"
 
   CreateEnvironment:
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     needs: [ Initialization ]
 
     steps:
@@ -90,7 +90,7 @@ jobs:
 
   PostProcess:
     if: always()
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     needs: [ Initialization,  CreateEnvironment ]
     steps:
       - name: Checkout

--- a/.github/workflows/CreatePerformanceTestApp.yaml
+++ b/.github/workflows/CreatePerformanceTestApp.yaml
@@ -41,7 +41,7 @@ defaults:
 
 jobs:
   Initialization:
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
@@ -55,7 +55,7 @@ jobs:
           eventId: "DO0102"
 
   Update:
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     needs: [ Initialization ]
 
     steps:
@@ -74,7 +74,7 @@ jobs:
 
   PostProcess:
     if: always()
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     needs: [ Initialization, Update ]
     steps:
       - name: Checkout

--- a/.github/workflows/CreateRelease.yaml
+++ b/.github/workflows/CreateRelease.yaml
@@ -49,7 +49,7 @@ defaults:
 
 jobs:
   Initialization:
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
@@ -63,7 +63,7 @@ jobs:
           eventId: "DO0094"
 
   CreateRelease:
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     needs: [ Initialization ]
     outputs:
       artifacts: ${{ steps.analyzeartifacts.outputs.artifacts }}
@@ -199,7 +199,7 @@ jobs:
 
   CreateReleaseBranch:
     if: ${{ github.event.inputs.createReleaseBranch=='Y' }}
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     needs: [ Initialization, CreateRelease, UploadArtifacts ]
     steps:
       - name: Checkout
@@ -215,7 +215,7 @@ jobs:
 
   UpdateVersionNumber:
     if: ${{ github.event.inputs.updateVersionNumber!='' }}
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     needs: [ Initialization, CreateRelease, UploadArtifacts ]
     steps:
       - name: Update Version Number
@@ -227,7 +227,7 @@ jobs:
 
   PostProcess:
     if: always()
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     needs: [ Initialization, CreateRelease, UploadArtifacts, CreateReleaseBranch, UpdateVersionNumber ]
     steps:
       - name: Checkout

--- a/.github/workflows/CreateTestApp.yaml
+++ b/.github/workflows/CreateTestApp.yaml
@@ -37,7 +37,7 @@ defaults:
 
 jobs:
   Initialization:
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
@@ -51,7 +51,7 @@ jobs:
           eventId: "DO0095"
 
   Update:
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     needs: [ Initialization ]
 
     steps:
@@ -69,7 +69,7 @@ jobs:
 
   PostProcess:
     if: always()
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     needs: [ Initialization, Update ]
     steps:
       - name: Checkout

--- a/.github/workflows/Current.yaml
+++ b/.github/workflows/Current.yaml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   Initialization:
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
       settings: ${{ steps.ReadSettings.outputs.SettingsJson }}
@@ -124,7 +124,7 @@ jobs:
 
   PostProcess:
     if: always()
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     needs: [ Initialization, Build ]
     steps:
       - name: Checkout

--- a/.github/workflows/IncrementVersionNumber.yaml
+++ b/.github/workflows/IncrementVersionNumber.yaml
@@ -25,7 +25,7 @@ defaults:
 
 jobs:
   Initialization:
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
@@ -39,7 +39,7 @@ jobs:
           eventId: "DO0096"
 
   Update:
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     needs: [ Initialization ]
 
     steps:
@@ -53,7 +53,7 @@ jobs:
   
   PostProcess:
     if: always()
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     needs: [ Initialization, Update ]
     steps:
       - name: Checkout

--- a/.github/workflows/NextMajor.yaml
+++ b/.github/workflows/NextMajor.yaml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   Initialization:
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
       settings: ${{ steps.ReadSettings.outputs.SettingsJson }}
@@ -124,7 +124,7 @@ jobs:
 
   PostProcess:
     if: always()
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     needs: [ Initialization, Build ]
     steps:
       - name: Checkout

--- a/.github/workflows/NextMinor.yaml
+++ b/.github/workflows/NextMinor.yaml
@@ -14,7 +14,7 @@ defaults:
 
 jobs:
   Initialization:
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
       settings: ${{ steps.ReadSettings.outputs.SettingsJson }}
@@ -124,7 +124,7 @@ jobs:
 
   PostProcess:
     if: always()
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     needs: [ Initialization, Build ]
     steps:
       - name: Checkout

--- a/.github/workflows/PublishToEnvironment.yaml
+++ b/.github/workflows/PublishToEnvironment.yaml
@@ -21,7 +21,7 @@ defaults:
 
 jobs:
   Initialization:
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     outputs:
       telemetryScopeJson: ${{ steps.init.outputs.telemetryScopeJson }}
     steps:
@@ -35,7 +35,7 @@ jobs:
           eventId: "DO0097"
 
   Analyze:
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     needs: [ Initialization ]
     outputs:
       settings: ${{ steps.ReadSettings.outputs.SettingsJson }}
@@ -130,7 +130,7 @@ jobs:
 
   PostProcess:
     if: always()
-    runs-on: [ self-hosted, 1ES.Pool=businesscentral ]
+    runs-on: [ windows-latest ]
     needs: [ Initialization, Analyze, Deploy ]
     steps:
       - name: Checkout


### PR DESCRIPTION
## preview

Note that when using the preview version of AL-Go for GitHub, you need to Update your AL-Go system files, as soon as possible when told to do so.

### Issues
- Issue #143 Commit Message for **Increment Version Number** workflow
- Issue #160 Create local DevEnv aith appDependencyProbingPaths
- Issue #156 Versioningstrategy 2 doesn't use 24h format
- Issue #155 Initial Add existing app fails with "Cannot find path"
- Issue #152 Error when loading dependencies from releases
- Issue #168 Regression in preview fixed

### AppSource Apps
- New workflow: Publish to AppSource
- Added new GitHub Action "Deliver" to deliver build output to Storage or AppSource
- Refactor CI/CD and Release workflows to use new deliver action

### Settings
- New Repo setting: CICDPushBranches can be specified as an array of branches, which triggers a CI/CD workflow on commit. Default is main', release/\*, feature/\*
- New Repo setting: CICDPullRequestBranches can be specified as an array of branches, which triggers a CI/CD workflow on pull request. Default is main
- New Repo setting: CICDSchedule can specify a CRONTab on when you want to run CI/CD on a schedule. Note that this will disable Push and Pull Request triggers unless specified specifically using CICDPushBranches or CICDPullRequestBranches
- New Repo setting: UpdateGitHubGoSystemFilesSchedule can specify a CRONTab on when you want to Update AL-Go System Files. Note that when running on a schedule, update AL-Go system files will perfom a direct commit and not create a pull request.
- New project Setting: AppSourceContext should be a compressed json structure containing authContext for submitting to AppSource. The BcContainerHelperFunction New-ALGoAppSourceContext will help you create this structure.
- New project Setting: AppSourceContinuousDelivery. Set this to true in enable continuous delivery for this project to AppSource. This requires AppSourceContext and AppSourceProductId to be set as well
- New project Setting: AppSourceProductId should be set to the product Id of this project in AppSource
- New project Setting: AppSourceMainAppFolder. If you have multiple appFolders, this is the folder name of the main app to submit to AppSource.

### All workflows
- Support 2 folder levels projects (apps\w1, apps\dk etc.)
- Better error messages for if an error occurs within an action
- Special characters are now supported in secrets
- Initial support for agents running inside containers on a host

### Update AL-Go System Files Workflow
- workflow now displays the currently used template URL when selecting the Run Workflow action

### CI/CD workflow
- Better detection of changed projects
- appDependencyProbingPaths did not support multiple projects in the same repository for latestBuild dependencies
- appDependencyProbingPaths with release=latestBuild only considered the last 30 artifacts
- Use mutex around ReadSecrets to ensure that multiple agents on the same host doesn't clash
- Add lfs when checking out files for CI/CD to support checking in dependencies

### CI/CD and Publish To New Environment
- Base functionality for selecting a specific GitHub runner for an environment

### localDevEnv.ps1 and cloudDevEnv.ps1
- Display clear error message if something goes wrong
